### PR TITLE
Switch to codecov-action@v3.15 which uses Node 20 until @v4 gets usable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -628,7 +628,7 @@ runs:
       Send the coverage data over to
       https://codecov.io/gh/${{ github.repository }}
     if: steps.ansible-test-command.outputs.has-coverage == 'true'
-    uses: codecov/codecov-action@v3
+    uses: codecov/codecov-action@v3.1.5
     with:
       files: >-
         ${{


### PR DESCRIPTION
Ref: https://github.com/codecov/codecov-action/issues/1289#issuecomment-1954510252